### PR TITLE
Add Docker setup with PHP 8, MySQL and nginx

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DB_HOST=db
+DB_PORT=3306
+DB_DATABASE=booking
+DB_USERNAME=booking_user
+DB_PASSWORD=secret

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM php:8.0-fpm
+
+# Install required PHP extensions
+RUN docker-php-ext-install pdo_mysql
+
+WORKDIR /var/www/html
+
+COPY . .
+
+CMD ["php-fpm"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    volumes:
+      - .:/var/www/html
+    environment:
+      DB_HOST: ${DB_HOST:-db}
+      DB_PORT: ${DB_PORT:-3306}
+      DB_DATABASE: ${DB_DATABASE}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+    depends_on:
+      - db
+
+  db:
+    image: mysql:8.0
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD:-secret}
+      MYSQL_DATABASE: ${DB_DATABASE}
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "${DB_PORT:-3306}:3306"
+    volumes:
+      - db-data:/var/lib/mysql
+
+  web:
+    image: nginx:latest
+    depends_on:
+      - app
+    volumes:
+      - .:/var/www/html
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "80:80"
+
+volumes:
+  db-data:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /var/www/html/public;
+    index index.php index.html;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        include fastcgi_params;
+        fastcgi_pass app:9000;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_index index.php;
+    }
+}


### PR DESCRIPTION
## Summary
- setup PHP 8 FPM Dockerfile
- add docker-compose with PHP, MySQL and nginx services
- provide default nginx config
- document sample database credentials in `.env.example`

## Testing
- `docker --version` *(fails: command not found)*
- `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e04cf8bc832fbc78dc3c693d3b7d