### PR TITLE
Add simple desk and booking pages

### DIFF
--- a/src/Controller/BookingController.php
+++ b/src/Controller/BookingController.php
@@ -8,6 +8,8 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 class BookingController extends AbstractController
@@ -31,5 +33,27 @@ class BookingController extends AbstractController
         $em->flush();
 
         return $this->json(['id' => $booking->getId()], 201);
+    }
+
+    #[Route('/bookings/create', name: 'booking_create_form', methods: ['POST'])]
+    public function createFromForm(Request $request, EntityManagerInterface $em, DeskRepository $deskRepository): RedirectResponse
+    {
+        $data = $request->request->all();
+        $desk = isset($data['desk_id']) ? $deskRepository->find($data['desk_id']) : null;
+        if (!$desk) {
+            $this->addFlash('error', 'Desk not found');
+            return $this->redirectToRoute('home');
+        }
+
+        $booking = new Booking();
+        $booking->setDesk($desk);
+        $booking->setUser($data['user'] ?? '');
+        $booking->setStartTime(new \DateTime($data['start_time'] ?? 'now'));
+        $booking->setEndTime(new \DateTime($data['end_time'] ?? 'now'));
+
+        $em->persist($booking);
+        $em->flush();
+
+        return $this->redirectToRoute('booking_list');
     }
 }

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Controller;
+
+use App\Repository\DeskRepository;
+use App\Repository\BookingRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class DefaultController extends AbstractController
+{
+    #[Route('/', name: 'home')]
+    public function index(DeskRepository $deskRepository): Response
+    {
+        $desks = $deskRepository->findAll();
+        return $this->render('desks/index.html.twig', [
+            'desks' => $desks,
+        ]);
+    }
+
+    #[Route('/bookings', name: 'booking_list', methods: ['GET'])]
+    public function bookings(BookingRepository $bookingRepository): Response
+    {
+        $bookings = $bookingRepository->findAll();
+        return $this->render('bookings/index.html.twig', [
+            'bookings' => $bookings,
+        ]);
+    }
+}

--- a/templates/bookings/index.html.twig
+++ b/templates/bookings/index.html.twig
@@ -1,0 +1,30 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Bookings{% endblock %}
+
+{% block body %}
+<h1>Bookings</h1>
+<table>
+    <tr>
+        <th>ID</th>
+        <th>Desk</th>
+        <th>User</th>
+        <th>Start</th>
+        <th>End</th>
+    </tr>
+    {% for booking in bookings %}
+        <tr>
+            <td>{{ booking.id }}</td>
+            <td>{{ booking.desk.name }}</td>
+            <td>{{ booking.user }}</td>
+            <td>{{ booking.startTime|date('Y-m-d H:i') }}</td>
+            <td>{{ booking.endTime|date('Y-m-d H:i') }}</td>
+        </tr>
+    {% else %}
+        <tr>
+            <td colspan="5">No bookings</td>
+        </tr>
+    {% endfor %}
+</table>
+<p><a href="{{ path('home') }}">Back to desks</a></p>
+{% endblock %}

--- a/templates/desks/index.html.twig
+++ b/templates/desks/index.html.twig
@@ -1,0 +1,21 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Desks{% endblock %}
+
+{% block body %}
+<h1>Available Desks</h1>
+{% for desk in desks %}
+    <h2>{{ desk.name }}</h2>
+    <form action="{{ path('booking_create_form') }}" method="post">
+        <input type="hidden" name="desk_id" value="{{ desk.id }}">
+        <label>User</label>
+        <input type="text" name="user" required>
+        <label>Start</label>
+        <input type="datetime-local" name="start_time" required>
+        <label>End</label>
+        <input type="datetime-local" name="end_time" required>
+        <button type="submit">Book</button>
+    </form>
+{% endfor %}
+<p><a href="{{ path('booking_list') }}">View bookings</a></p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- provide a DefaultController with homepage and booking list pages
- extend BookingController with form-based booking creation
- add Twig templates for desks and bookings

## Testing
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6863e37ccf54832f9c3e2a1dc2f8751b